### PR TITLE
use comma separation with string type instead of comma_delimited_list

### DIFF
--- a/1vm-1lnet-1floatingip.yaml
+++ b/1vm-1lnet-1floatingip.yaml
@@ -30,10 +30,10 @@ parameters:
     description: The keypair that will be used for the instances
 
   dns:
-    type: comma_delimited_list
+    type: string
     label: DNS nameservers
     description: Comma separated list of DNS nameservers for the private network
-    default: '8.8.8.8'
+    default: "8.8.8.8"
 
 resources:
    # Create the logical network
@@ -48,7 +48,7 @@ resources:
       properties:
          name: subnet_1
          cidr: 10.10.10.0/24
-         dns_nameservers:[ { get_param: dns } ]
+         dns_nameservers: [ { get_param: dns } ]
          enable_dhcp: true
          gateway_ip: 10.10.10.1
          network_id: { get_resource: lnet_1 }
@@ -103,4 +103,3 @@ outputs:
    instance1_floating_ip:
       description: Floating IP address of instance1 on external network.
       value: { get_attr: [ instance1_floating_ip, floating_ip_address] }
-


### PR DESCRIPTION
comma_delimited_list seems to not render into horizon correctly, so just don't use that type.